### PR TITLE
Added the 'Icon' field.

### DIFF
--- a/functions/post-type-plugins.php
+++ b/functions/post-type-plugins.php
@@ -710,6 +710,13 @@ class DTPS_Plugins_Post_Type
             'default' => 'https://raw.githubusercontent.com/DiscipleTools/disciple-tools-version-control/master/images/dt-placeholder-1544x500.jpg',
             'section' => 'plugin_version_control_fields',
         );
+        $fields['icon'] = array(
+            'name' => 'Icon',
+            'description' => '',
+            'type' => 'text',
+            'default' => '',
+            'section' => 'plugin_version_control_fields',
+        );
         $fields['author'] = array(
             'name' => 'Author',
             'description' => '',


### PR DESCRIPTION
The Add New Plugin page now picks up the version-contro.json 'Icon' field upon triggering the remote sync.